### PR TITLE
Enhancement of delete functionality

### DIFF
--- a/src/lib/server/models/answerpossibility.ts
+++ b/src/lib/server/models/answerpossibility.ts
@@ -15,7 +15,7 @@ export class AnswerPossibility extends Model<
 > {
 	declare id: CreationOptional<number>;
 	declare isTeacher: boolean;
-	declare personId: ForeignKey<Person["id"]> | null;
+	declare personId: ForeignKey<Person["id"]>;
 	declare createdAt: CreationOptional<Date>;
 	declare updatedAt: CreationOptional<Date>;
 }

--- a/src/lib/server/models/user.ts
+++ b/src/lib/server/models/user.ts
@@ -15,7 +15,7 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
 	declare gender?: gender;
 	declare mail?: string;
 	declare code: string;
-	declare personId: ForeignKey<Person["id"]> | null;
+	declare personId: ForeignKey<Person["id"]>;
 
 	declare createdAt: CreationOptional<Date>;
 	declare updatedAt: CreationOptional<Date>;

--- a/src/lib/server/utilities.ts
+++ b/src/lib/server/utilities.ts
@@ -30,7 +30,6 @@ export async function check_delete_person(id: number) {
 		const possibility = await AnswerPossibility.findOne({ where: { personId: id } });
 
 		if (possibility === null) {
-			console.log(id);
 			await Person.destroy({ where: { id: id } });
 		}
 	}

--- a/src/lib/server/utilities.ts
+++ b/src/lib/server/utilities.ts
@@ -1,4 +1,7 @@
 import { redirect } from "@sveltejs/kit";
+import { Person } from "$lib/server/models/person";
+import { User } from "$lib/server/models/user";
+import { AnswerPossibility } from "$lib/server/models/answerpossibility";
 
 export const rdr_to_login = () => {
 	throw redirect(302, "/login_admin");
@@ -19,3 +22,16 @@ export const compare_nums = (one: number | undefined, two: number | undefined): 
 
 	return one < two;
 };
+
+export async function check_delete_person(id: number) {
+	const user = await User.findOne({ where: { personId: id } });
+
+	if (user === null) {
+		const possibility = await AnswerPossibility.findOne({ where: { personId: id } });
+
+		if (possibility === null) {
+			console.log(id);
+			await Person.destroy({ where: { id: id } });
+		}
+	}
+}

--- a/src/routes/admin/possibilities/[type]/+page.svelte
+++ b/src/routes/admin/possibilities/[type]/+page.svelte
@@ -32,8 +32,14 @@
 	}
 
 	function remove_possibility(index: number) {
-		possibilities.splice(index, 1);
-		possibilities = [...possibilities];
+		if (
+			confirm(
+				"Bist du dir sicher, dass du diese Antwortmöglichkeit löschen möchtest? Alle zusammenhängenden Antworten werden ebenfalls gelöscht",
+			)
+		) {
+			possibilities.splice(index, 1);
+			possibilities = [...possibilities];
+		}
 	}
 </script>
 

--- a/src/routes/admin/questions/+page.server.ts
+++ b/src/routes/admin/questions/+page.server.ts
@@ -1,5 +1,7 @@
 import type { PageServerLoad } from "./$types";
 import { Question } from "$lib/server/models/question";
+import { Answer } from "$lib/server/models/answer";
+import { PairAnswer } from "$lib/server/models/pairanswer";
 
 interface inQuestion {
 	question: string;
@@ -93,14 +95,12 @@ export const actions: Actions = {
 			await Question.update(question, { where: { id: question.id } });
 		}
 
-		const removables: Array<number> = [];
-
-		question_ids.forEach((number) => {
-			if (!in_ids.includes(number)) {
-				removables.push(number);
+		for (const id of question_ids) {
+			if (!in_ids.includes(id)) {
+				await Answer.destroy({ where: { questionId: id } });
+				await PairAnswer.destroy({ where: { questionId: id } });
+				await Question.destroy({ where: { id: id } });
 			}
-		});
-
-		await Question.destroy({ where: { id: removables } });
+		}
 	},
 };

--- a/src/routes/admin/questions/+page.svelte
+++ b/src/routes/admin/questions/+page.svelte
@@ -40,9 +40,14 @@
 	}
 
 	function remove_question(event, index: number) {
-		event.preventDefault();
-		questions.splice(index, 1);
-		questions = [...questions];
+		if (
+			confirm(
+				"Bist du dir sicher, dass du diese Frage löschen möchtest? Alle zusammenhängenden Antworten werden ebenfalls gelöscht",
+			)
+		) {
+			questions.splice(index, 1);
+			questions = [...questions];
+		}
 	}
 </script>
 
@@ -136,7 +141,7 @@
 					<div class="col-span-2 sm:col-span-1 sm:place-self-center">
 						<button
 							class="w-full rounded-xl bg-white p-3 text-slate-900"
-							on:click={(event) => remove_question(event, i)}>Entfernen</button
+							on:click|preventDefault={(event) => remove_question(event, i)}>Entfernen</button
 						>
 					</div>
 					{#if question.id}

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -4,6 +4,8 @@ import { randomBytes } from "crypto";
 import { User } from "$lib/server/models/user";
 import { AnswerPossibility } from "$lib/server/models/answerpossibility";
 import { Person } from "$lib/server/models/person";
+import { Answer } from "$lib/server/models/answer";
+import { PairAnswer } from "$lib/server/models/pairanswer";
 
 interface inPerson {
 	id?: number;
@@ -139,11 +141,13 @@ export const actions: Actions = {
 
 		const removables: Array<number> = [];
 
-		user_ids.forEach((number) => {
-			if (!processed.includes(number)) {
-				removables.push(number);
+		for (const id of user_ids) {
+			if (!processed.includes(id)) {
+				removables.push(id);
+				await Answer.destroy({ where: { userId: id } });
+				await PairAnswer.destroy({ where: { userId: id } });
 			}
-		});
+		}
 
 		await User.destroy({ where: { id: removables } });
 	},

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -7,6 +7,8 @@ import { Person } from "$lib/server/models/person";
 import { Answer } from "$lib/server/models/answer";
 import { PairAnswer } from "$lib/server/models/pairanswer";
 
+import { check_delete_person } from "$lib/server/utilities";
+
 interface inPerson {
 	id?: number;
 	forename: string;
@@ -18,7 +20,12 @@ interface inUser {
 	mail?: string;
 	gender?: "m" | "w" | "d";
 	code: string;
-	personId: number | null;
+	personId?: number;
+}
+
+interface fetchedUser {
+	id: number;
+	personId: number;
 }
 
 export const load: PageServerLoad = async ({ url }) => {
@@ -52,12 +59,12 @@ export const load: PageServerLoad = async ({ url }) => {
 export const actions: Actions = {
 	users: async ({ request }) => {
 		// fetch user ids to check what needs to be deleted later
-		const user_ids = (
+		const db_users: Array<fetchedUser> = (
 			await User.findAll({
-				attributes: ["id"],
+				attributes: ["id", "personId"],
 			})
 		).map((user) => {
-			return user.dataValues.id;
+			return user.dataValues;
 		});
 
 		const data = await request.formData();
@@ -66,7 +73,6 @@ export const actions: Actions = {
 
 		let current_user: inUser = {
 			id: undefined,
-			personId: null,
 			code: "",
 		};
 
@@ -111,7 +117,6 @@ export const actions: Actions = {
 
 				current_user = {
 					id: undefined,
-					personId: null,
 					code: "",
 				};
 
@@ -139,17 +144,16 @@ export const actions: Actions = {
 
 		await processEntry();
 
-		const removables: Array<number> = [];
-
-		for (const id of user_ids) {
+		for (const { id, personId } of db_users) {
 			if (!processed.includes(id)) {
-				removables.push(id);
 				await Answer.destroy({ where: { userId: id } });
 				await PairAnswer.destroy({ where: { userId: id } });
+
+				await User.destroy({ where: { id: id } });
+
+				await check_delete_person(personId);
 			}
 		}
-
-		await User.destroy({ where: { id: removables } });
 	},
 	generate: async () => {
 		const possibilities = (

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -16,10 +16,16 @@
 	});
 
 	function remove_user(index: number) {
-		users.splice(index, 1);
-		users = [...users].sort((a, b) => {
-			return a.surname.localeCompare(b.surname);
-		});
+		if (
+			confirm(
+				"Bist du dir sicher, dass du diesen Nutzer löschen möchtest? Alle Antworten dieses Nutzers werden ebenfalls gelöscht",
+			)
+		) {
+			users.splice(index, 1);
+			users = [...users].sort((a, b) => {
+				return a.surname.localeCompare(b.surname);
+			});
+		}
 	}
 </script>
 


### PR DESCRIPTION
**Description**
At the moment, if you delete something like a question or an answer possibility, all connected database entries (like answers) remain in the database; causing inconsistencies and problems in the evaluation. This change adds following enhancements that should fix such problems:

- [x] delete confirmation
- [x] deletion of related entries in the database

**Issue**
Closes #32 
